### PR TITLE
Fix armour not shown on client-side after login

### DIFF
--- a/src/PiggyAuth/Main.php
+++ b/src/PiggyAuth/Main.php
@@ -454,6 +454,7 @@ class Main extends PluginBase
         }
         if ($this->getConfig()->getNested("effects.hide-items")) {
             $player->getInventory()->sendContents($player);
+            $player->getInventory()->sendArmorContents($player);
         }
         if ($this->getConfig()->getNested("login.adventure-mode")) {
             if ($this->sessionmanager->getSession($player)->getGamemode() !== null) {


### PR DESCRIPTION
By not sending the armour content's to the player again, the client couldn't see it's armour, even after authenticating.

This pull request adds a small code addition to resend the armour content.