### PR TITLE
Support API 3.0.0-ALPHA7 (Fixes for breaking changes)

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,13 +1,13 @@
 name: PiggyAuth
 main: PiggyAuth\Main
-version: 3.0.0.20
-api: [2.0.0, 3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5]
+version: 3.0.0.21
+api: [3.0.0-ALPHA7]
 load: POSTWORLD
 author: DaPigGuy
 permissions:
  piggyauth:
   default: op
-  description: "Allows using all PiggyAuth features" 
+  description: "Allows using all PiggyAuth features"
   children:
     piggyauth.command:
       default: op
@@ -54,4 +54,4 @@ permissions:
           description: "Allow using /setlanguage"
         piggyauth.command.unregister:
           default: true
-          description: "Allow using /unregister"          
+          description: "Allow using /unregister"

--- a/src/PiggyAuth/Commands/ChangeEmailCommand.php
+++ b/src/PiggyAuth/Commands/ChangeEmailCommand.php
@@ -31,7 +31,7 @@ class ChangeEmailCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/ChangePasswordCommand.php
+++ b/src/PiggyAuth/Commands/ChangePasswordCommand.php
@@ -32,7 +32,7 @@ class ChangePasswordCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/ConvertCommand.php
+++ b/src/PiggyAuth/Commands/ConvertCommand.php
@@ -31,7 +31,7 @@ class ConvertCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/ForgotPasswordCommand.php
+++ b/src/PiggyAuth/Commands/ForgotPasswordCommand.php
@@ -32,7 +32,7 @@ class ForgotPasswordCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/KeyCommand.php
+++ b/src/PiggyAuth/Commands/KeyCommand.php
@@ -33,7 +33,7 @@ class KeyCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/LoginCommand.php
+++ b/src/PiggyAuth/Commands/LoginCommand.php
@@ -32,7 +32,7 @@ class LoginCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/LogoutCommand.php
+++ b/src/PiggyAuth/Commands/LogoutCommand.php
@@ -32,7 +32,7 @@ class LogoutCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/PiggyAuthCommand.php
+++ b/src/PiggyAuth/Commands/PiggyAuthCommand.php
@@ -5,6 +5,7 @@ namespace PiggyAuth\Commands;
 use PiggyAuth\Main;
 use pocketmine\command\PluginCommand;
 use pocketmine\Server;
+use pocketmine\plugin\Plugin;
 
 /**
  * Class PiggyAuthCommand
@@ -15,7 +16,7 @@ class PiggyAuthCommand extends PluginCommand
     /**
      * @return Main
      */
-    public function getPlugin()
+    public function getPlugin(): Plugin
     {
         return Server::getInstance()->getPluginManager()->getPlugin("PiggyAuth");
     }

--- a/src/PiggyAuth/Commands/PinCommand.php
+++ b/src/PiggyAuth/Commands/PinCommand.php
@@ -32,7 +32,7 @@ class PinCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/PreregisterCommand.php
+++ b/src/PiggyAuth/Commands/PreregisterCommand.php
@@ -34,7 +34,7 @@ class PreregisterCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/RegisterCommand.php
+++ b/src/PiggyAuth/Commands/RegisterCommand.php
@@ -33,7 +33,7 @@ class RegisterCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/ResetPasswordCommand.php
+++ b/src/PiggyAuth/Commands/ResetPasswordCommand.php
@@ -33,7 +33,7 @@ class ResetPasswordCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/SendPinCommand.php
+++ b/src/PiggyAuth/Commands/SendPinCommand.php
@@ -32,7 +32,7 @@ class SendPinCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/SetLanguageCommand.php
+++ b/src/PiggyAuth/Commands/SetLanguageCommand.php
@@ -33,7 +33,7 @@ class SetLanguageCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/Commands/UnregisterCommand.php
+++ b/src/PiggyAuth/Commands/UnregisterCommand.php
@@ -32,7 +32,7 @@ class UnregisterCommand extends PiggyAuthCommand
      * @param array $args
      * @return bool
      */
-    public function execute(CommandSender $sender, $currentAlias, array $args)
+    public function execute(CommandSender $sender, string $currentAlias, array $args)
     {
         if (!$this->testPermission($sender)) {
             return true;

--- a/src/PiggyAuth/FakeAttribute.php
+++ b/src/PiggyAuth/FakeAttribute.php
@@ -30,7 +30,7 @@ class FakeAttribute extends Attribute
     /**
      * @return mixed
      */
-    public function getMinValue()
+    public function getMinValue(): float
     {
         return $this->min;
     }
@@ -38,7 +38,7 @@ class FakeAttribute extends Attribute
     /**
      * @return mixed
      */
-    public function getMaxValue()
+    public function getMaxValue(): float
     {
         return $this->max;
     }
@@ -46,7 +46,7 @@ class FakeAttribute extends Attribute
     /**
      * @return mixed
      */
-    public function getValue()
+    public function getValue(): float
     {
         return $this->value;
     }
@@ -54,7 +54,7 @@ class FakeAttribute extends Attribute
     /**
      * @return mixed
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -62,7 +62,7 @@ class FakeAttribute extends Attribute
     /**
      * @return mixed
      */
-    public function getDefaultValue()
+    public function getDefaultValue(): float
     {
         return $this->min;
     }

--- a/src/PiggyAuth/Main.php
+++ b/src/PiggyAuth/Main.php
@@ -140,7 +140,6 @@ class Main extends PluginBase
         }
         if ($this->getConfig()->getNested("message.boss-bar")) {
             Entity::registerEntity(Wither::class);
-            $this->getServer()->getNetwork()->registerPacket(BossEventPacket::NETWORK_ID, BossEventPacket::class);
         }
         switch ($this->getConfig()->getNested("database")) {
             case "mysql":

--- a/src/PiggyAuth/Main.php
+++ b/src/PiggyAuth/Main.php
@@ -826,7 +826,7 @@ class Main extends PluginBase
             $this->getServer()->getPluginManager()->callEvent(new PlayerFailEvent($this, $player, self::FORGET_PASSWORD, self::PASSWORD_USERNAME));
             return false;
         }
-        $newpassword = $this->hashPassword($newpassword);;
+        $newpassword = $this->hashPassword($newpassword);
         $newpin = $this->generatePin($player);
         $this->getServer()->getPluginManager()->callEvent($event = new PlayerForgetPasswordEvent($this, $player, $newpassword, $pin, $newpin));
         if (!$event->isCancelled()) {

--- a/src/PiggyAuth/Main.php
+++ b/src/PiggyAuth/Main.php
@@ -1002,7 +1002,7 @@ class Main extends PluginBase
     /**
      * @return mixed
      */
-    public function getFile()
+    public function getFile(): string
     {
         return parent::getFile();
     }

--- a/src/PiggyAuth/Sessions/PiggyAuthSession.php
+++ b/src/PiggyAuth/Sessions/PiggyAuthSession.php
@@ -568,6 +568,12 @@ class PiggyAuthSession implements Session
             $pk->bossEid = $wither->getId();
             $pk->eventType = BossEventPacket::TYPE_SHOW;
             $pk->healthPercent = 1;
+            $pk->playerEid = $this->player->getId();
+            $pk->unknownShort = 0;
+            $pk->unknownVarint1 = 0;
+            $pk->unknownVarint2 = 0;
+            $pk->color = 0;
+            $pk->overlay = 0;
             $pk->title = $message;
             $this->player->dataPacket($pk);
         }

--- a/src/PiggyAuth/Tasks/AttributeTick.php
+++ b/src/PiggyAuth/Tasks/AttributeTick.php
@@ -28,7 +28,7 @@ class AttributeTick extends PluginTask
     /**
      * @param $currentTick
      */
-    public function onRun($currentTick)
+    public function onRun(int $currentTick)
     {
         foreach ($this->plugin->getServer()->getOnlinePlayers() as $player) {
             if ($this->plugin->getSessionManager()->getSession($player) !== null && !$this->plugin->getSessionManager()->getSession($player)->isAuthenticated()) {

--- a/src/PiggyAuth/Tasks/DelayedPinTask.php
+++ b/src/PiggyAuth/Tasks/DelayedPinTask.php
@@ -28,7 +28,7 @@ class DelayedPinTask extends PluginTask
     /**
      * @param $currentTick
      */
-    public function onRun($currentTick)
+    public function onRun(int $currentTick)
     {
         $this->player->sendMessage(str_replace("{pin}", $this->plugin->getSessionManager()->getSession($this->player)->getPin(), $this->plugin->getLanguageManager()->getMessage($this->player, "register-success")));
     }

--- a/src/PiggyAuth/Tasks/KeyTick.php
+++ b/src/PiggyAuth/Tasks/KeyTick.php
@@ -25,7 +25,7 @@ class KeyTick extends PluginTask
     /**
      * @param $currentTick
      */
-    public function onRun($currentTick)
+    public function onRun(int $currentTick)
     {
         $this->plugin->keytime += 1;
         if ($this->plugin->keytime >= 300) { //5 Mins

--- a/src/PiggyAuth/Tasks/MessageTick.php
+++ b/src/PiggyAuth/Tasks/MessageTick.php
@@ -25,7 +25,7 @@ class MessageTick extends PluginTask
     /**
      * @param $currentTick
      */
-    public function onRun($currentTick)
+    public function onRun(int $currentTick)
     {
         foreach ($this->plugin->getServer()->getOnlinePlayers() as $player) {
             if ($this->plugin->getSessionManager()->getSession($player) !== null && !$this->plugin->getSessionManager()->getSession($player)->isAuthenticated()) {

--- a/src/PiggyAuth/Tasks/OtherMessageTypeTick.php
+++ b/src/PiggyAuth/Tasks/OtherMessageTypeTick.php
@@ -29,7 +29,7 @@ class OtherMessageTypeTick extends PluginTask
     /**
      * @param $currentTick
      */
-    public function onRun($currentTick)
+    public function onRun(int $currentTick)
     {
         foreach ($this->plugin->getServer()->getOnlinePlayers() as $player) {
             if ($this->plugin->getSessionManager()->getSession($player) !== null && !$this->plugin->getSessionManager()->getSession($player)->isAuthenticated()) {

--- a/src/PiggyAuth/Tasks/PingTask.php
+++ b/src/PiggyAuth/Tasks/PingTask.php
@@ -29,7 +29,7 @@ class PingTask extends PluginTask
     /**
      * @param $currentTick
      */
-    public function onRun($currentTick)
+    public function onRun(int $currentTick)
     {
         $ping = $this->db->db->ping();
         if(!$ping){

--- a/src/PiggyAuth/Tasks/TimeoutTask.php
+++ b/src/PiggyAuth/Tasks/TimeoutTask.php
@@ -28,7 +28,7 @@ class TimeoutTask extends PluginTask
     /**
      * @param $currentTick
      */
-    public function onRun($currentTick)
+    public function onRun(int $currentTick)
     {
         foreach ($this->plugin->getServer()->getOnlinePlayers() as $player) {
             $session = $this->plugin->getSessionManager()->getSession($player);


### PR DESCRIPTION
# DO NOT REMOVE THIS
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting: Not sure about the return type formatting, as I couldn't find an example
- * [x] Must test on PMMP: [version](https://github.com/pmmp/PocketMine-MP/tree/7c00982fff060951748283e74bae69de8dd833b2)
- * [x] ***PLEASE*** don't use the GitHub Web Editor: your wish is my command
- * [x] Have a detailed title like "Fix players are being kicked randomly"

#### **What does the PR change?**
<!-- Does your Pull Request fix a bug? Enhancements to the plugin? -->
[Recently pmmp updated it's api version to 3.0.0-ALPHA7](https://github.com/pmmp/PocketMine-MP/commit/7f99d9019ac30dcd41aecdf8a30c7378ddb1dfc6) which also introduced a few breaking changes for plugins. This pr aims to make the plugin usable for this version of pmmp again.

But because these changes aren't backwards compatible, this pr also edits the plugin.yml's api version list by only leaving 3.0.0-ALPHA7 in it (Only compatible version at the moment).

This is not the only change to the plugin.yml file.
To be able to distinguish this version and older ones better, I increased the plugin version from 3.0.0.20 to 3.0.0.21

#### **Extra Information**
<!-- Anything else we should know? -->
[Example for breaking changes](https://github.com/pmmp/PocketMine-MP/commit/46a2e6cbf8f1fd71e632b1d3b4ccc34492683721)

Tested on this [version of pmmp](https://github.com/pmmp/PocketMine-MP/tree/7c00982fff060951748283e74bae69de8dd833b2)
