### PR TITLE
Fixes the "Data too long for column 'xbox' at row 1" error

### DIFF
--- a/src/PiggyAuth/Databases/MySQL.php
+++ b/src/PiggyAuth/Databases/MySQL.php
@@ -130,7 +130,7 @@ class MySQL implements Database
      */
     public function insertDataWithoutPlayerObject($player, $password, $email, $pin, $auth = "PiggyAuth", callable $callback = null, $args = null)
     {
-        $task = new MySQLTask($this->plugin->getConfig()->get("mysql"), "INSERT INTO players (name, password, email, pin, uuid, attempts, xbox, language, auth) VALUES ('" . $this->db->escape_string(strtolower($player)) . "', '" . $this->db->escape_string($password) . "', '" . $this->db->escape_string($email) . "', '" . intval($pin) . "', 'uuid', '0', 'false', '" . $this->db->escape_string($this->plugin->getLanguageManager()->getDefaultLanguage()) . "', '" . $this->db->escape_string($auth) . "')");
+        $task = new MySQLTask($this->plugin->getConfig()->get("mysql"), "INSERT INTO players (name, password, email, pin, uuid, attempts, xbox, language, auth) VALUES ('" . $this->db->escape_string(strtolower($player)) . "', '" . $this->db->escape_string($password) . "', '" . $this->db->escape_string($email) . "', '" . intval($pin) . "', 'uuid', '0', false, '" . $this->db->escape_string($this->plugin->getLanguageManager()->getDefaultLanguage()) . "', '" . $this->db->escape_string($auth) . "')");
         $this->plugin->getServer()->getScheduler()->scheduleAsyncTask($task);
     }
 


### PR DESCRIPTION
# DO NOT REMOVE THIS
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Must test on PMMP
- * [ ] ***PLEASE*** don't use the GitHub Web Editor (I don't care xD it's just a small change)
- * [x] Have a detailed title like "Fix players are being kicked randomly"

#### **What does the PR change?**
<!-- Does your Pull Request fix a bug? Enhancements to the plugin? -->
This fixed the "Data too long for column 'xbox' at row 1" MySQL error when converting from any auth plugin to PiggyAuth SQL

#### **Extra Information**
<!-- Anything else we should know? -->
Please test this more than I did, don't have enough time for that